### PR TITLE
Fix shorthand for 'Advanced Vector Extensions'; add information about AVX2 and AVX-512

### DIFF
--- a/cours-sc/sl1-intro.tex
+++ b/cours-sc/sl1-intro.tex
@@ -532,6 +532,8 @@
 	SSSE3 & Supplemental Streaming SIMD Extension & 2006 \\
 	SSE4 & & 2007 \\
 	AVX & Advanced Vector Extensions & 2011 \\
+	AVX2 &  & 2013 \\
+	AVX-512 &  & 2015 \\
     }
 
     \vspace* {3mm}

--- a/cours-sc/sl1-intro.tex
+++ b/cours-sc/sl1-intro.tex
@@ -269,7 +269,7 @@
 
 \begin {frame} {Motivations -- Performances}
     Conclusion~:
-    
+
     \begin {itemize}
 	\item on ne peut plus tellement réduire le temps de cycle
 	\item on peut encore mettre davantage de transistors sur la
@@ -531,12 +531,12 @@
 	SSE3 & & 2004 \\
 	SSSE3 & Supplemental Streaming SIMD Extension & 2006 \\
 	SSE4 & & 2007 \\
-	AVE & Advanced Vector Extensions & 2011 \\
+	AVX & Advanced Vector Extensions & 2011 \\
     }
 
     \vspace* {3mm}
     \implique évolutions successives (et non changement radical)
-    
+
 \end {frame}
 
 \begin {frame} {Classification de Flynn -- SIMD}


### PR DESCRIPTION
- The correct shorthand for "Advanced Vector Extensions" is "AVX". 
- There are two more vector instruction sets on current Intel CPUs. We might want to add these for the sake of completeness.
